### PR TITLE
fix: avoid hardcoded exec path

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -92,8 +92,7 @@ MainWindow::~MainWindow()
     }
 
     if (m_isFirst) {
-        QFile file(DDE_STARTGUIDE_PATH);
-        if (file.exists()) {
+        if (!DDE_STARTGUIDE_PATH.isEmpty()) {
             QProcess *pStartAppProcess = new QProcess(this);
             pStartAppProcess->startDetached(DDE_STARTGUIDE_PATH);
         }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -43,10 +43,11 @@
 DCORE_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
-#define DDE_STARTGUIDE_PATH "/usr/bin/dde-startguide"
 #define FIRST_ICONCONTENT_WINSIZE 278
 
 using WMSwitcherInter = com::deepin::WMSwitcher;
+
+const QString DDE_STARTGUIDE_PATH = QStandardPaths::findExecutable("dde-startguide");
 
 class BaseModuleWidget;
 class MainWindow : public DMainWindow


### PR DESCRIPTION
Replace /usr/bin/dde-startguide with dde-startguide in src/mainwindow.h; refactor error handling logic accordingly in src/mainwindow.cpp

Related: linuxdeepin/developer-center#3374

The commit message should be fixed now, please review this PR and merge if there are no outstanding issues.